### PR TITLE
Fix the timing of updating contextmenu after changing options.

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -15,6 +15,8 @@ chrome.extension.onMessage.addListener(
   function (request, sender, sendResponse) {
     if ( request.command == 'setClipboard' ) {
       copyToClipboard(request.data);
+    } else if ( request.command == 'updateContextMenus' ) {
+      updateContextMenus();
     }
   }
 );
@@ -95,7 +97,7 @@ function onMenuItemClick(contextMenuIdList, info, tab) {
 	copyToClipboard(linkText);
 }
 
-window.addEventListener('load', function () {
+function updateContextMenus() {
   var contextMenuIdList = {};
 
   chrome.contextMenus.removeAll();
@@ -122,5 +124,8 @@ window.addEventListener('load', function () {
     var n = Number(info.menuItemId.split(/-/).pop());
     onMenuItemClick(contextMenuIdList, info, tab);
   })
+}
 
+window.addEventListener('load', function () {
+  updateContextMenus();
 }, false);

--- a/extension/options.js
+++ b/extension/options.js
@@ -15,6 +15,11 @@ window.addEventListener( 'load', function () {
       ctable._listener.onUpdated = function () {
         var json = ctable.serialize();
         localStorage[localStorageKey] = json;
+
+        // Update context menus
+        chrome.extension.sendMessage({
+          command: 'updateContextMenus',
+        });
       }
       window.ctable = ctable;
     }catch(e){


### PR DESCRIPTION
Fix a problem as follows
# :ok_hand: :ok_hand: :ok_hand: Expected :ok_hand: :ok_hand: :ok_hand:
1. I hope to change context menus of CreateLink extension. :smile: 
2. Push "Configure..." button on the extension popup and open a options window.
3. Change "Formats" data.  :blush:
4. Righ click and show context menu on an web pages and select "Copy Link as ..." .
5.  **I can select a item from updated items of CreateLink.** :ok_hand:
# :shit: :shit: :shit: Actual :shit: :shit: :shit:

1..4. Same.

last 5. I can **NOT SEE** updated items. :frowning: They are old items still. :broken_heart:
# :computer: :computer: :computer: Environments :computer: :computer: :computer:
- Chromium Version 25.0.1364.160 Ubuntu 12.04 (25.0.1364.160-0ubuntu0.12.04.1)
