### PR TITLE
Modified to enable for local files

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -19,7 +19,7 @@
    "name": "Create Link",
    "options_page": "options.html",
    "content_scripts" : [{
-     "matches"    : ["http://*/*", "https://*/*"],
+     "matches"    : ["http://*/*", "https://*/*", "file:///*/*"],
      "css"        : [],
      "js"         : [
        "content.js"


### PR DESCRIPTION
I noticed that we can't use this useful extension for local HTMLs and modified manifest.
