### PR TITLE
Escape vertical bar

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -17,7 +17,7 @@ function CreateLink() {
 CreateLink.default_formats = [
     {label: "Plain text", format: '%text% %url%' },
     {label: "HTML", format: '<a href="%url%">%htmlEscapedText%</a>' },
-    {label: "markdown", format: '[%text%](%url%)' },
+    {label: "markdown", format: '[%text_vb%](%url%)' },
     {label: "mediaWiki", format: '[%url% %text%]' },
 ];
 
@@ -76,6 +76,7 @@ CreateLink.prototype.formatLinkText = function (formatId, url, text, title, tabI
     replace(/%text%/g, text.replace(/\n/g, ' ')).
     replace(/%text_n%/g, text).
     replace(/%text_br%/g, text.replace(/\n/g, '<br />\n')).
+    replace(/%text_vb%/g, text.replace(/\|/g, '\\\|')).
     replace(/%title%/g, title).
     replace(/%newline%/g, '\n').
     replace(/%htmlEscapedText%/g, escapeHTML(text)).

--- a/extension/options.html
+++ b/extension/options.html
@@ -59,7 +59,9 @@
 		<dt>%text_n%</dt>
 		<dd>Selected text or page title. All newlines are copied as they are.</dd>
 		<dt>%text_br%</dt>
-		<dd>Selected text or page title. All newlines are converted to "&lt;br /&gt;\n".</dd></dd>
+		<dd>Selected text or page title. All newlines are converted to "&lt;br /&gt;\n".</dd>
+		<dt>%text_vb%</dt>
+		<dd>Selected text or page title. All vertical bars are converted to "\|".</dd>
 		<dt>%title%</dt>
 		<dd>Page title.</dd>
 		<dt>%newline%</dt>


### PR DESCRIPTION
when I used CreateLink/markdown in the page include vertical bar (|) in the title, 
paseted text is shown as Table in markdown.
so I fixed this issue.

thank you.