### PR TITLE
add keyboard shortcuts (addresses #13)

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -249,9 +249,16 @@ function onKeyboardShortcut(command) {
         var target = instance();
         var label = target.getDefaultFormat();
         var formatId = target.indexOfFormatByLabel(label);
-        var info = {};
-        onMenuItemClick(formatId, info, tab);
-        flashBadge('success', label);
+        if (formatId >= 0) {
+          var info = {};
+          onMenuItemClick(formatId, info, tab);
+          flashBadge('success', label);
+        } else {
+          // User has never set the default or else the previously-defaulted
+          //  format was probably removed, so let user know,
+          //  but don't automatically reset the default for her/him
+          flashBadge('fail');
+        }
       });
       break;
   }

--- a/extension/background.js
+++ b/extension/background.js
@@ -28,17 +28,37 @@ CreateLink.prototype.copyToClipboard = function (text) {
   document.execCommand("copy");
 }
 
+var formatPreferencesKey = 'format_preferences';
+var defaultFormatKey = 'defaultFormat';
+
+CreateLink.prototype.setDefaultFormat = function (value) {
+  localStorage[defaultFormatKey] = value;
+};
+
+CreateLink.prototype.getDefaultFormat = function () {
+  return localStorage[defaultFormatKey];
+};
+
+CreateLink.prototype.setFormatPreferences = function (formatsString) {
+  localStorage[formatPreferencesKey] = formatsString;
+};
+
+CreateLink.prototype.getFormatPreferences = function () {
+  return JSON.parse(localStorage[formatPreferencesKey] || '[]');
+};
+
 CreateLink.prototype.readFormats = function () {
   var formats;
   try {
-    formats = JSON.parse( localStorage.format_preferences );
+    formats = this.getFormatPreferences();
   } catch(e) {
   }
-  if ( !formats ) {
+  if ( !formats || formats.length == 0 ) {
     formats = CreateLink.default_formats;
   }
   return formats;
-}
+};
+
 function escapeHTML(text) {
   return text ? text.replace(/[&<>'"]/g, convertHTMLChar) : text;
 }
@@ -82,7 +102,7 @@ CreateLink.prototype.formatLinkText = function (formatId, url, text, title, tabI
     replace(/%htmlEscapedText%/g, escapeHTML(text)).
     replace(/\\t/g, '\t').
     replace(/\\n/g, '\n');
-  
+
   var m = data.match(/%input%/g);
   if (m) {
     var inputDeferreds = m.map(function () {
@@ -167,7 +187,7 @@ function updateContextMenus() {
 
 window.addEventListener('load', function () {
   updateContextMenus();
-  
+
   document.addEventListener('copy', function (ev) {
     ev.preventDefault();
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -7,19 +7,43 @@ function getCurrentTab(callback) {
   });
 }
 
-function onKeyboardShortcut(command) {
-  switch (command) {
-    case 'current-tab-link':
-      getCurrentTab(function (tab) {
-        var target = instance();
-        var label = target.getDefaultFormat();
-        var formatId = target.indexOfFormatByLabel(label);
-        var info = {};
-        onMenuItemClick(formatId, info, tab);
-      });
+function flashBadge(type, text) {
+  // Taken from https://github.com/chitsaou/copy-as-markdown/
+  var color;
+
+  switch (type) {
+    case "success":
+      color = "#738a05";
       break;
+    case "fail":
+      color = "#d11b24";
+      text = "!";
+      break;
+    default:
+      return; // don't know what it is. quit.
   }
+
+  chrome.browserAction.setBadgeText({
+    "text": text
+  });
+
+  chrome.browserAction.setBadgeBackgroundColor({
+    "color": color
+  });
+
+  function clearBadge(type, text) {
+    chrome.browserAction.setBadgeText({
+      text: ""
+    });
+
+    chrome.browserAction.setBadgeBackgroundColor({
+      color: [0, 0, 0, 255] // opaque
+    });
+  }
+
+  setTimeout(clearBadge, 3000);
 }
+
 chrome.commands.onCommand.addListener(onKeyboardShortcut);
 
 chrome.extension.onMessage.addListener(
@@ -216,6 +240,21 @@ function updateContextMenus() {
     var formatId = contextMenuIdList[info.menuItemId];
     onMenuItemClick(formatId, info, tab);
   })
+}
+
+function onKeyboardShortcut(command) {
+  switch (command) {
+    case 'current-tab-link':
+      getCurrentTab(function (tab) {
+        var target = instance();
+        var label = target.getDefaultFormat();
+        var formatId = target.indexOfFormatByLabel(label);
+        var info = {};
+        onMenuItemClick(formatId, info, tab);
+        flashBadge('success', label);
+      });
+      break;
+  }
 }
 
 window.addEventListener('load', function () {

--- a/extension/cocoatable.js
+++ b/extension/cocoatable.js
@@ -145,13 +145,25 @@
 			nextCell.open();
 		}
 	}
+	CocoaTable.prototype.onSelectedRowChanged = function (callback) {
+		// FUTURE add cleanup of previous listener
+		return this._table.addEventListener('selectedRowChanged', callback);
+	}
 	CocoaTable.prototype.setSelectedRow = function (row) {
+		var prevRow = this._selectedRow;
 		if ( this._selectedRow ) {
 			removeClass(this._selectedRow, 'selected');
 		}
 		if ( row )
 			addClass(row, 'selected');
 		this._selectedRow = row;
+		var event = new CustomEvent('selectedRowChanged', {
+			'detail': {
+				'previous': prevRow,
+				'current': this._selectedRow
+			}
+		});
+		this._table.dispatchEvent(event);
 	}
 	CocoaTable.prototype.emptyRowObjectRepresentation = function () {
 		return this._index2name.reduce( function (j, i) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -27,6 +27,11 @@
      "run_at"     : "document_end",
      "all_frames" : true
    }],
+   "commands": {
+    "current-tab-link": {
+      "description": "current tab in default format"
+    }
+   },
    "permissions": [ "tabs", "http://*/*", "https://*/*", "contextMenus" ],
    "version": "0.2.11"
 }

--- a/extension/options.html
+++ b/extension/options.html
@@ -29,6 +29,12 @@
 		</div>
 	</div>
 	
+	<h2>Default Format</h2>
+	<p>Select the format from the table below that should be used when the keyboard shortcut is activated.</p>
+	<!-- when table row is selected, show selection below  -->
+	<p>Default is currently <em id="current-default-format">{{defaultFormatName}}</em></p>
+	<button id="set-default-format"></button>
+
 	<h2>Formats</h2>
 	<div id="configuration">
 		<table id="cocoatable" class="cocoatable"> 

--- a/extension/options.js
+++ b/extension/options.js
@@ -4,16 +4,16 @@ window.addEventListener( 'load', function () {
   version.innerText = manifest.version;
 
   chrome.runtime.getBackgroundPage(function (backgroundWindow) {
-    var instance = backgroundWindow.instance();
-    var formats = instance.formats;
+    var target = backgroundWindow.instance();
+    var formats = target.formats;
 
     var defaultFormatButton = document.getElementById('set-default-format');
-    var currentDefault = instance.getDefaultFormat();
+    var currentDefault = target.getDefaultFormat();
     document.getElementById('current-default-format').textContent = String(currentDefault);
     defaultFormatButton.textContent = 'Set default to ' + currentDefault;
     defaultFormatButton.addEventListener('click', function () {
       var v = defaultFormatButton.getAttribute('data-selected-value');
-      instance.setDefaultFormat(v);
+      target.setDefaultFormat(v);
       document.getElementById('current-default-format').textContent = v;
     });
     
@@ -35,7 +35,7 @@ window.addEventListener( 'load', function () {
 
       ctable._listener.onUpdated = function () {
         var json = ctable.serialize();
-        instance.setFormatPreferences(json);
+        target.setFormatPreferences(json);
 
         // Update context menus
         chrome.extension.sendMessage({

--- a/extension/options.js
+++ b/extension/options.js
@@ -2,6 +2,7 @@ window.addEventListener( 'load', function () {
   var manifest = chrome.runtime.getManifest();
   var version = document.getElementById("version");
   version.innerText = manifest.version;
+  var defaultFormatValueStorageAttribute = 'data-selected-value';
 
   chrome.runtime.getBackgroundPage(function (backgroundWindow) {
     var target = backgroundWindow.instance();
@@ -9,12 +10,13 @@ window.addEventListener( 'load', function () {
 
     var defaultFormatButton = document.getElementById('set-default-format');
     var currentDefault = target.getDefaultFormat();
-    document.getElementById('current-default-format').textContent = String(currentDefault);
+    var currentDefaultEl = document.getElementById('current-default-format');
+    currentDefaultEl.textContent = String(currentDefault);
     defaultFormatButton.textContent = 'Set default to ' + currentDefault;
     defaultFormatButton.addEventListener('click', function () {
-      var v = defaultFormatButton.getAttribute('data-selected-value');
+      var v = defaultFormatButton.getAttribute(defaultFormatValueStorageAttribute);
       backgroundWindow.instance().setDefaultFormat(v);
-      document.getElementById('current-default-format').textContent = v;
+      currentDefaultEl.textContent = v;
     });
     
     try{
@@ -24,10 +26,12 @@ window.addEventListener( 'load', function () {
       
       ctable.onSelectedRowChanged(function (rowEvent) {
         try {
+          // This would happen while the user is in the middle of
+          //  editing/creating a new format. Safe to ignore, so we do.
           var currentSelectedRow = rowEvent.detail.current;
           var selectedName = currentSelectedRow.querySelector('span').textContent;
           defaultFormatButton.textContent = 'Set default to ' + selectedName;
-          defaultFormatButton.setAttribute('data-selected-value', selectedName);
+          defaultFormatButton.setAttribute(defaultFormatValueStorageAttribute, selectedName);
         } catch (e) {
           console.log(e);
         }

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,29 +1,50 @@
 window.addEventListener( 'load', function () {
-  var localStorageKey = 'format_preferences';
-
-  var manifest = chrome.runtime.getManifest();;
+  var manifest = chrome.runtime.getManifest();
   var version = document.getElementById("version");
   version.innerText = manifest.version;
 
   chrome.runtime.getBackgroundPage(function (backgroundWindow) {
-    var formats = backgroundWindow.instance().formats;
+    var instance = backgroundWindow.instance();
+    var formats = instance.formats;
+
+    var defaultFormatButton = document.getElementById('set-default-format');
+    var currentDefault = instance.getDefaultFormat();
+    document.getElementById('current-default-format').textContent = String(currentDefault);
+    defaultFormatButton.textContent = 'Set default to ' + currentDefault;
+    defaultFormatButton.addEventListener('click', function () {
+      var v = defaultFormatButton.getAttribute('data-selected-value');
+      instance.setDefaultFormat(v);
+      document.getElementById('current-default-format').textContent = v;
+    });
     
     try{
-      var ctable	= new CocoaTable(formats, [
+      var ctable = new CocoaTable(formats, [
         'label', 'format', 'filter'
       ] );
+      
+      ctable.onSelectedRowChanged(function (rowEvent) {
+        try {
+          var currentSelectedRow = rowEvent.detail.current;
+          var selectedName = currentSelectedRow.querySelector('span').textContent;
+          defaultFormatButton.textContent = 'Set default to ' + selectedName;
+          defaultFormatButton.setAttribute('data-selected-value', selectedName);
+        } catch (e) {
+          console.log(e);
+        }
+      });
+
       ctable._listener.onUpdated = function () {
         var json = ctable.serialize();
-        localStorage[localStorageKey] = json;
+        instance.setFormatPreferences(json);
 
         // Update context menus
         chrome.extension.sendMessage({
-          command: 'updateContextMenus',
+          command: 'updateContextMenus'
         });
-      }
+      };
       window.ctable = ctable;
     }catch(e){
-      console.log(e)
+      console.log(e);
     }
   });
   

--- a/extension/options.js
+++ b/extension/options.js
@@ -13,7 +13,7 @@ window.addEventListener( 'load', function () {
     defaultFormatButton.textContent = 'Set default to ' + currentDefault;
     defaultFormatButton.addEventListener('click', function () {
       var v = defaultFormatButton.getAttribute('data-selected-value');
-      target.setDefaultFormat(v);
+      backgroundWindow.instance().setDefaultFormat(v);
       document.getElementById('current-default-format').textContent = v;
     });
     
@@ -35,7 +35,7 @@ window.addEventListener( 'load', function () {
 
       ctable._listener.onUpdated = function () {
         var json = ctable.serialize();
-        target.setFormatPreferences(json);
+        backgroundWindow.instance().setFormatPreferences(json);
 
         // Update context menus
         chrome.extension.sendMessage({


### PR DESCRIPTION
Borrowing from https://github.com/chitsaou/copy-as-markdown/, I implemented this to close https://github.com/ku/CreateLink/issues/13.

### Some unexpected bumps
Chrome keyboard shortcuts using the standard mechanism need to be specified in the manifest, so you can't use that to have a unique shortcut for each *format* (well, you can for the default formats, but not for user-defined ones). That lead me to decide on having the user set the "default" format that will be used for context-menu-less operations (keyboard shortcut, for one). Instead, I could have popped up a context menu when you used the shortcut, but that seemed challenging and also like it would be annoying 90% of the time.

Another gotcha was the lack of visual confirmation when you used the keyboard shortcut. I copied `flashBadge` from https://github.com/chitsaou/copy-as-markdown/ to achieve that (it puts whatever the *label*/Name is for the format into the badge area momentarily [3 seconds]):
![HTML](https://cloud.githubusercontent.com/assets/6391742/16213540/5e2b617a-370d-11e6-9f9e-0c5e2dc59a89.png)
![Plain Text](https://cloud.githubusercontent.com/assets/6391742/16213542/62002808-370d-11e6-94d2-9939bac10a3e.png)
![markdown](https://cloud.githubusercontent.com/assets/6391742/16213612/f59d9046-370d-11e6-8315-313dc3e6180c.png)
![mediaWiki](https://cloud.githubusercontent.com/assets/6391742/16213607/eb9b4048-370d-11e6-8163-d4c3fc5513a0.png)


What do you think? After using it for a bit, I rather like the idea of setting a default and never having to visit the options page again.

http://recordit.co/umul3v2xpW